### PR TITLE
Added GitHub action for maven build in Windows

### DIFF
--- a/.github/workflows/maven_ubuntu.yml
+++ b/.github/workflows/maven_ubuntu.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Maven build - Ubuntu latest
 
 on:
   push:
@@ -21,4 +21,4 @@ jobs:
       with:
         java-version: '14.0.1'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -e clean test --file pom.xml

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -1,0 +1,24 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Maven build - Windows latest
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: '14.0.1'
+    - name: Build with Maven
+      run: mvn -e clean test --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.java</groupId>
     <artifactId>icing</artifactId>
-    <version>2020.10.30</version>
+    <version>2020.11.13</version>
 
     <properties>
         <maven.compiler.target>14</maven.compiler.target>

--- a/src/main/resources/utilities/I18N_Resource_Bundle_en_US.properties
+++ b/src/main/resources/utilities/I18N_Resource_Bundle_en_US.properties
@@ -10,7 +10,6 @@ utilities.I18NUtility.property.found=Resource bundle %s contains property %s
 utilities.I18NUtility.property.missing=Resource bundle %s does not contain property %s
 utilities.I18NUtility.resourcebundle.add=Adding resource bundle - %s
 utilities.I18NUtility.resourcebundle.remove=Removing resource bundle - %s
-utilities.ShellUtility.execute=%s -c "%s"
 utilities.RegexUtility.pattern.count=Count of %s pattern in given regex - %d
 utilities.ShellUtility.executing=Executing - %s
 utilities.StringUtility.repeatString.error.negativeRepeatCount=repeatCount cannot be negative (%d).

--- a/src/main/resources/utilities/icing.properties
+++ b/src/main/resources/utilities/icing.properties
@@ -44,6 +44,12 @@ utilities.I18NUtility.resourcebundle.default=I18N_Resource_Bundle
 utilities.ShellUtility.linux.which=which %s
 utilities.ShellUtility.windows.where=where %s
 utilities.ShellUtility.timeout=5
+# suppress inspection "UnusedProperty"
+utilities.ShellUtility.template.BASH=%s -c "%s"
+# suppress inspection "UnusedProperty"
+utilities.ShellUtility.template.CMD=%s /C "%s"
+# suppress inspection "UnusedProperty"
+utilities.ShellUtility.template.POWERSHELL=%s /C "%s"
 
 test.FileUtilityTest.action.perform.waittime.milliseconds=1000
 test.FileUtilityTest.create.directories.recursively.waittime.milliseconds=1000

--- a/src/test/java/FileUtilityTest.java
+++ b/src/test/java/FileUtilityTest.java
@@ -32,14 +32,16 @@ class FileUtilityTest {
     private static final ConcurrentHashMap<String, Queue<WatchEvent.Kind<?>>> actualPathToEventKindMap = new ConcurrentHashMap<>();
 
     public FileUtilityTest() {
-        testBedPath = Paths.get(PropertyUtility.getProperty("common.dir.temp")).resolve("FUT");
+        testBedPath = Paths.get(PropertyUtility.getProperty("common.dir.temp"))
+            .resolve("FUT")
+            .toAbsolutePath();
     }
 
     public void createTestBed() {
         clearTestBed();
 
         try {
-            Files.createDirectory(testBedPath);
+            Files.createDirectories(testBedPath);
         } catch (IOException e) {
             logger.error(e);
         }

--- a/src/test/java/ShellUtilityTest.java
+++ b/src/test/java/ShellUtilityTest.java
@@ -25,8 +25,8 @@ class ShellUtilityTest {
 
         nonTerminatingCommand = new ShellUtility.Command();
         nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.BASH, "cat");
-        nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.CMD, "");
-        nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.POWERSHELL, "");
+        nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.CMD, "ping 127.0.0.1 -n 4294967295");
+        nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.POWERSHELL, "ping 127.0.0.1 -n 4294967295");
 
         timeoutDuration = Duration.ofSeconds(5);
 


### PR DESCRIPTION
Closes #68.

**Fixed issues with ShellUtility and ShellUtilityTest on Windows systems**    

    Previously, ShellUtility and ShellUtilityTest had the following problems:
     - Non terminating commands for CMD and POWERSHELL weren't defined.
     - Template to execute commands via a specified shell wasn't compatible with CMD and POWERSHELL.
     - Execution of commands fail if multiple executables of the same shell type is found.

    The above mentioned issues have been fixed as follows:
     - Non terminating commands for CMD and POWERSHELL have been defined.
     - Separate command execution templates have been defined for each type of shell.
     - If multiple executables of the same shell type is found, use the first entry.

**Fixed issue in FileUtilityTest where test bed wasn't created on Windows**

    By default, the "tmp" directory doesn't exist in the root partition of a
    Windows system. Modified FilUtility to create that if that's the case.

**Added GitHub action for maven build in Windows**

    Added a github action to run maven build and tests on Windows when:
     - A PR is opened against master
     - When a commit is pushed to master