### PR TITLE
Add MacOS support for maven build GitHub action

### DIFF
--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -1,0 +1,24 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Maven build - MacOS latest
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: '14.0.1'
+    - name: Build with Maven
+      run: mvn -e clean test --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.java</groupId>
     <artifactId>icing</artifactId>
-    <version>2020.11.13</version>
+    <version>2020.11.19</version>
 
     <properties>
         <maven.compiler.target>14</maven.compiler.target>

--- a/src/main/java/utilities/OS.java
+++ b/src/main/java/utilities/OS.java
@@ -1,21 +1,38 @@
 package utilities;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public enum OS {
     WINDOWS,
     LINUX,
+    MAC_OS_X,
     UNKNOWN;
 
+    private static Logger logger = LogManager.getLogger(OS.class);
+
+    /**
+     * Detects the OS of the machine in which this method is called.
+     * @return The detected OS. If it's unable to detect, it will return UNKNOWN.
+     */
     public static OS getOs() {
-        String os = System.getProperty("os.name").toUpperCase();
-        System.out.println(os.contains("LINUX"));
-        if(os.contains("LINUX")) {
-            return LINUX;
+        String osString = System.getProperty("os.name")
+                .toUpperCase();
+        logger.debug("OS string: " + osString);
+        OS detectedOS;
+        if(osString.contains("LINUX")) {
+            detectedOS = LINUX;
         }
-        else if(os.contains("WINDOWS")) {
-            return WINDOWS;
+        else if(osString.contains("WINDOWS")) {
+            detectedOS = WINDOWS;
+        }
+        else if(osString.contains("MAC OS X")) {
+            detectedOS = MAC_OS_X;
         }
         else {
-            return UNKNOWN;
+            detectedOS = UNKNOWN;
         }
+        logger.info("OS detected: " + detectedOS);
+        return detectedOS;
     }
 }

--- a/src/main/resources/utilities/icing.properties
+++ b/src/main/resources/utilities/icing.properties
@@ -42,10 +42,13 @@ test.prop=TEST PROPERTY
 utilities.FileUtility.bgthread.watchservice.switch=true
 utilities.I18NUtility.resourcebundle.default=I18N_Resource_Bundle
 utilities.ShellUtility.linux.which=which %s
+utilities.ShellUtility.macos.which=which %s
 utilities.ShellUtility.windows.where=where %s
 utilities.ShellUtility.timeout=5
 # suppress inspection "UnusedProperty"
 utilities.ShellUtility.template.BASH=%s -c "%s"
+# suppress inspection "UnusedProperty"
+utilities.ShellUtility.template.ZSH=%s -c "%s"
 # suppress inspection "UnusedProperty"
 utilities.ShellUtility.template.CMD=%s /C "%s"
 # suppress inspection "UnusedProperty"

--- a/src/test/java/ShellUtilityTest.java
+++ b/src/test/java/ShellUtilityTest.java
@@ -22,11 +22,13 @@ class ShellUtilityTest {
         command.setCommand(ShellUtility.TypeOfShell.BASH, "ls -al /");
         command.setCommand(ShellUtility.TypeOfShell.CMD, "dir");
         command.setCommand(ShellUtility.TypeOfShell.POWERSHELL, "dir");
+        command.setCommand(ShellUtility.TypeOfShell.ZSH, "ls -al /");
 
         nonTerminatingCommand = new ShellUtility.Command();
         nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.BASH, "cat");
         nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.CMD, "ping 127.0.0.1 -n 4294967295");
         nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.POWERSHELL, "ping 127.0.0.1 -n 4294967295");
+        nonTerminatingCommand.setCommand(ShellUtility.TypeOfShell.ZSH, "cat");
 
         timeoutDuration = Duration.ofSeconds(5);
 
@@ -35,6 +37,7 @@ class ShellUtilityTest {
         typeOfShell = switch(os) {
             case WINDOWS -> ShellUtility.TypeOfShell.CMD;
             case LINUX -> ShellUtility.TypeOfShell.BASH;
+            case MAC_OS_X -> ShellUtility.TypeOfShell.ZSH;
             default -> null;
         };
     }


### PR DESCRIPTION
```
Added Mac OS X support for ShellUtility and ShellUtilityTest

Closes #95.
Added ZSH support to ShellUtility so that it can be supported in
MAC OS X.
```
```
Skip WatchService related tests for Mac OS X

Closes #94.
Currently there's a known OpenJDK bug for WatchService (https://bugs.openjdk.java.net/browse/JDK-7133447)
where it doesn't or takes a very long time to generate filesystem events.
Since the WatchService API for Mac OS X isn't reliable, we are skipping
testing it and will not support this.
```
```
Added a GitHub action to run a maven build against Mac OS X

Closes #94.
Added a github action to run maven build and tests on Mac OS when:
 - A PR is opened against master
 - When a commit is pushed to master
```