### PR TITLE
Fixed GitHub package release action

### DIFF
--- a/.github/workflows/package_publish.yml
+++ b/.github/workflows/package_publish.yml
@@ -1,7 +1,7 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
 
-name: Maven Package
+name: Publish to GitHub packages
 
 on:
   release:
@@ -11,13 +11,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: '14.0.1'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.java</groupId>
     <artifactId>icing</artifactId>
-    <version>2020.11.19</version>
+    <version>2020.12.16</version>
 
     <properties>
         <maven.compiler.target>14</maven.compiler.target>
@@ -30,7 +30,7 @@
         <repository>
             <id>github</id>
             <name>java-icing MVN package deployment</name>
-            <url>https://maven.pkg.github.com/the-c0d3br34k3r/java-icing</url>
+            <url>https://maven.pkg.github.com/padaiyal/jIcing</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Closes #100.
The previous publish action tries to package using JDK 1.8 so it fails.
It has been changed to JDK 14 for it to succeed.